### PR TITLE
Update cache docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,25 @@ ollama pull all-minilm
 ```
 
 Per embedding, fastembed is actually much slower, but due to the overhead of making requests to ollama, for large directories, the embeddings cache builds much faster when using fastembed.
+
+## Embeddings cache
+
+Csep stores chunk embeddings in a SQLite database located under your system
+cache directory (for example `~/.cache/csep`). Each embedding model has its own
+database file so caches do not clash when you switch models. Performing a
+search automatically prunes the cache by removing records for files that no
+longer exist or that have changed since they were cached.
+
+The cache can be explicitly managed with the `csep cache` subcommand:
+
+```sh
+# build or refresh the cache for the current directory
+csep cache --build
+
+# remove any stale entries without deleting the database
+csep cache --prune
+
+# delete the cache completely
+csep cache --clear
+```
+

--- a/docs/csep.1
+++ b/docs/csep.1
@@ -44,6 +44,17 @@ Prints help information and exits.
 \fB\-V\fR, \fB\--version\fR
 Prints version information and exits.
 
+.SH CACHE COMMANDS
+.TP
+.B csep cache --build
+Build or refresh the embeddings cache for the current directory.
+.TP
+.B csep cache --clear
+Remove all cached embeddings.
+.TP
+.B csep cache --prune
+Prune stale entries from the cache.
+
 .SH AUTHOR
 Written by Divan Visagie (\fBme@divanv.com\fR).
 
@@ -69,6 +80,15 @@ Set the client to "ollama":
 .TP
 Do not print the query with the results:
 .B csep -n "first string" "second string"
+.TP
+Build an embeddings cache:
+.B csep cache --build
+.TP
+Clear the cache completely:
+.B csep cache --clear
+.TP
+Prune stale cache entries:
+.B csep cache --prune
 
 .SH SEE ALSO
 For more information, visit the official repository or contact the author.


### PR DESCRIPTION
## Summary
- document SQLite cache location and pruning in `README.md`
- add new man page section for cache subcommands
- document cache examples

## Testing
- `cargo test` *(fails: ort-sys build script can't fetch package)*

------
https://chatgpt.com/codex/tasks/task_e_68549a12515883319f75af56b0f11737