### PR TITLE
Use sqlite cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ tiktoken-rs = "0.6.0"
 tokio = { version = "1.41.1", features = ["full"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
+rusqlite = { version = "0.31.0", features = ["bundled"] }

--- a/src/cache/db.rs
+++ b/src/cache/db.rs
@@ -1,0 +1,90 @@
+use std::path::{Path, PathBuf};
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+use crate::chunker::Chunk;
+
+pub struct CacheDB {
+    conn: Connection,
+}
+
+pub fn get_db_path() -> PathBuf {
+    dirs::cache_dir().unwrap().join("csep").join("embeddings.sqlite")
+}
+
+impl CacheDB {
+    pub fn new() -> Result<Self> {
+        let path = get_db_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let conn = Connection::open(path)?;
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS embeddings (
+                path TEXT,
+                hash TEXT,
+                model TEXT,
+                line INTEGER,
+                chunk TEXT,
+                embedding BLOB
+            )",
+            [],
+        )?;
+        let db = CacheDB { conn };
+        db.clean_removed_files()?;
+        Ok(db)
+    }
+
+    pub fn get_chunks(&self, path: &str, hash: &str, model: &str) -> Result<Option<Vec<Chunk>>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT line, chunk, embedding FROM embeddings WHERE path=?1 AND hash=?2 AND model=?3 ORDER BY line",
+        )?;
+        let rows = stmt.query_map(params![path, hash, model], |row| {
+            let line: i64 = row.get(0)?;
+            let text: String = row.get(1)?;
+            let blob: Vec<u8> = row.get(2)?;
+            let embeddings: Vec<f32> = bincode::deserialize(&blob).unwrap_or_default();
+            Ok(Chunk { line: line as usize, text, embeddings })
+        })?;
+        let mut chunks = Vec::new();
+        for row in rows {
+            chunks.push(row?);
+        }
+        if chunks.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(chunks))
+        }
+    }
+
+    pub fn upsert_chunks(&self, path: &str, hash: &str, model: &str, chunks: &[Chunk]) -> Result<()> {
+        let tx = self.conn.transaction()?;
+        tx.execute("DELETE FROM embeddings WHERE path=?1 AND model=?2", params![path, model])?;
+        let mut stmt = tx.prepare(
+            "INSERT INTO embeddings (path, hash, model, line, chunk, embedding) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        )?;
+        for chunk in chunks {
+            let blob = bincode::serialize(&chunk.embeddings)?;
+            stmt.execute(params![path, hash, model, chunk.line as i64, chunk.text, blob])?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn delete_file(&self, path: &str) -> Result<()> {
+        self.conn.execute("DELETE FROM embeddings WHERE path=?1", params![path])?;
+        Ok(())
+    }
+
+    pub fn clean_removed_files(&self) -> Result<()> {
+        let mut stmt = self.conn.prepare("SELECT DISTINCT path FROM embeddings")?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        for row in rows {
+            let path: String = row?;
+            if !Path::new(&path).exists() {
+                self.conn.execute("DELETE FROM embeddings WHERE path=?1", params![path])?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,0 +1,1 @@
+pub mod db;

--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf};
+use std::fs;
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -8,6 +8,7 @@ use tiktoken_rs::cl100k_base;
 use tracing::warn;
 
 use crate::{
+    cache::db::CacheDB,
     clients::{EmbeddingsClient, EmbeddingsClientImpl},
     files::read_file_with_fallback,
 };
@@ -19,10 +20,6 @@ pub struct Chunk {
     pub embeddings: Vec<f32>,
 }
 
-pub fn get_cache_path() -> PathBuf {
-    let tmp_dir = dirs::cache_dir().unwrap();
-    tmp_dir.join("csep").join("embeddings")
-}
 
 pub fn count_lines_in_text(text: &str) -> usize {
     text.lines().count()
@@ -43,23 +40,12 @@ pub async fn get_chunks_and_embeddings_or_load_from_cache<'a>(
     };
 
     let hash_of_file = Sha256::digest(file_text.as_bytes());
-    let cache_file_name = format!("{:x}.cache", hash_of_file);
-    let file_path = get_cache_path().join(cache_file_name);
+    let hash_string = format!("{:x}", hash_of_file);
+    let db = CacheDB::new()?;
+    let model = embeddings_client.model_name();
 
-    if file_path.exists() {
-        match bincode::deserialize(&fs::read(&file_path)?) {
-            Ok(chunks) => {
-                return Ok((file.to_string(), chunks));
-            }
-            Err(err) => {
-                warn!("Error deserializing cache file {}: {}", file, err);
-                // Delete the file, if we cant read from it, its probably corrupt
-                match fs::remove_file(&file_path) {
-                    Ok(_) => (),
-                    Err(err) => warn!("Error removing cache file {}: {}", file, err),
-                }
-            }
-        };
+    if let Some(chunks) = db.get_chunks(file, &hash_string, &model)? {
+        return Ok((file.to_string(), chunks));
     }
 
     let tokenizer = cl100k_base()?;
@@ -84,8 +70,7 @@ pub async fn get_chunks_and_embeddings_or_load_from_cache<'a>(
         })
         .collect();
 
-    fs::create_dir_all(get_cache_path())?;
-    fs::write(file_path, bincode::serialize(&chunks)?)?;
+    db.upsert_chunks(file, &hash_string, &model, &chunks)?;
 
     Ok((file.to_string(), chunks))
 }

--- a/src/clients/fastembed.rs
+++ b/src/clients/fastembed.rs
@@ -28,6 +28,10 @@ impl FastEmbeddingsClient {
             model
         }
     }
+
+    pub fn model_name(&self) -> &str {
+        "all-MiniLM-L6-v2"
+    }
 }
 
 #[async_trait]

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -20,6 +20,15 @@ pub enum EmbeddingsClientImpl {
     FastEmbed(FastEmbeddingsClient),
 }
 
+impl EmbeddingsClientImpl {
+    pub fn model_name(&self) -> String {
+        match self {
+            EmbeddingsClientImpl::Ollama(client) => client.model_name(),
+            EmbeddingsClientImpl::FastEmbed(client) => client.model_name().to_string(),
+        }
+    }
+}
+
 #[async_trait]
 impl EmbeddingsClient for EmbeddingsClientImpl {
     async fn get_embeddings(&self, text: &[&str]) -> Result<Vec<Vec<f32>>> {

--- a/src/clients/ollama.rs
+++ b/src/clients/ollama.rs
@@ -18,6 +18,10 @@ impl OllamaEmbeddingsClient {
             model: model.unwrap_or("all-minilm".to_string()),
         }
     }
+
+    pub fn model_name(&self) -> String {
+        self.model.clone()
+    }
 }
 
 #[derive(Debug, Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use spinners::{Spinner, Spinners};
 use tracing::error;
 use utils::{cosine_similarity, get_stdin};
 
-use crate::chunker::get_cache_path;
+use crate::cache::db::get_db_path;
 
 mod args;
 mod chunker;
@@ -55,9 +55,9 @@ async fn main() {
         match subcmd {
             SubCommands::Cache(cache_args) => {
                 if cache_args.clear {
-                    let path = get_cache_path();
+                    let path = get_db_path();
                     if path.exists() {
-                        match std::fs::remove_dir_all(path) {
+                        match std::fs::remove_file(&path) {
                             Ok(_) => println!("Cache cleared"),
                             Err(err) => error!("Error clearing cache: {}", err),
                         }


### PR DESCRIPTION
## Summary
- replace file-based chunk cache with SQLite storage
- expose model names from embedding clients
- use the new DB for caching chunks
- clear cache by removing SQLite file

## Testing
- `cargo fmt`
- `cargo test` *(fails: Failed to GET `https://parcel.pyke.io/...`)*

------
https://chatgpt.com/codex/tasks/task_e_68549a01a3ac83319c17cf3694ce1fc2